### PR TITLE
Clean

### DIFF
--- a/Daruin.cpp
+++ b/Daruin.cpp
@@ -11,7 +11,6 @@
 #include <QTextStream>
 #include <QFileDialog>
 #include <stdio.h>//This library is needed only during debug
-#include <iostream>//
 
 Daruin::Daruin(void)
 {

--- a/Daruin.cpp
+++ b/Daruin.cpp
@@ -11,19 +11,19 @@
 #include <QTextStream>
 #include <QFileDialog>
 #include <stdio.h>//This library is needed only during debug
+#include <iostream>//
 
 Daruin::Daruin(void)
 {
     textEditor = new QTextEdit;
     menubar = new QMenuBar;
     fileMenu = new QMenu("file");
-    str = new QString;
 
     dialog = new QDialog;
     layout_h = new QHBoxLayout;
     layout_v = new QVBoxLayout;
-    label = new QLabel;
-    yesButton = new QPushButton;
+    label = new QLabel("you haven't save this file yet.\nwill you save?");
+    yesButton = new QPushButton("yes");
     noButton = new QPushButton("no");
     cancelButton = new QPushButton("cancel");
     fileDialog = new QFileDialog();
@@ -31,7 +31,6 @@ Daruin::Daruin(void)
     fileName = new QString("");
     fileState = '\0';
     changeState = false;
-    saveState = false;
 
     setCentralWidget(textEditor);
     menubar->addMenu(fileMenu);
@@ -57,8 +56,10 @@ Daruin::Daruin(void)
     connect(menubar->addAction("serial monitor") , SIGNAL(triggered()) , this , SLOT(call()));
 
     connect(textEditor , SIGNAL(textChanged()) , this , SLOT(change()));
-    connect(cancelButton , SIGNAL(clicked()) , this , SLOT(close_dialog()));
+    connect(yesButton , SIGNAL(clicked()) , this , SLOT(openFileWithSave()));
     connect(noButton , SIGNAL(clicked()) , this , SLOT(openFileWithoutSave()));
+	connect(cancelButton , SIGNAL(clicked()) , dialog , SLOT(hide()));
+    connect(fileDialog,SIGNAL(fileSelected(QString)),this,SLOT(openFileWithName(QString)));
 }
 
 void Daruin::call(void)
@@ -74,14 +75,10 @@ void Daruin::change(void)
 void Daruin::displayAskSaveDialog(void)
 {
     if(changeState){
-        yesButton->setText("yes");
-        label->setText("you haven't save this file yet.\nwill you save?");
-        noButton->show();
-        connect(yesButton , SIGNAL(clicked()) , this , SLOT(openFileWithSave()));
         dialog->move(500 , 300);
         dialog->show();
     } else {
-        openFile();
+        openFileWithoutSave();
     }
 }
 
@@ -101,26 +98,14 @@ void Daruin::openExistedFile(void)
 
 void Daruin::openFile(void)
 {
-    close_dialog();
-
     switch(fileState){
         case 'n' : {
-            if(saveState) saveFile();
-            if(saveState){
-                soState = 'n';
-            }else {
-                textEditor->clear();
-                fileName = new QString("");
-            }
+            textEditor->clear();
+            fileName->clear();
             break;
         }
         case 'e' : {
-            if(saveState) saveFile();
-            if(saveState) {
-                soState = 'e';
-            } else {
-                displayAskFileNameDialog();
-            }
+            displayAskFileNameDialog();
             break;
         }
     }
@@ -129,27 +114,29 @@ void Daruin::openFile(void)
 void Daruin::openFileWithSave(void)
 {
     printf("yes\n");
-    saveState = true;
-    openFile();
+    dialog->hide();
+    saveFile();
+    if(*fileName != NULL){
+        openFile();
+    }
 }
 
 void Daruin::openFileWithoutSave(void)
 {
     printf("no\n");
-    saveState = false;
+    dialog->hide();
     openFile();
 }
 
 void Daruin::displayAskFileNameDialog(void)
 {
     printf("open essentially\n");
-    fileState = 'o';
     fileDialog->show();
-    connect(fileDialog,SIGNAL(fileSelected(QString)),this,SLOT(openFileWithName(QString)));
 }
 
 void Daruin::openFileWithName(QString name)
 {
+	*fileName = name;
     currentFile = new QFile(name);
     if(currentFile->open(QIODevice::ReadOnly)){
         QTextStream in(currentFile);
@@ -157,7 +144,8 @@ void Daruin::openFileWithName(QString name)
     } else {
         printf("Error: Can't open file");
     }
-    close_dialog();
+    fileDialog->hide();
+    delete currentFile;
 }
 
 void Daruin::saveFile(void)
@@ -168,47 +156,21 @@ void Daruin::saveFile(void)
         if(currentFile->open(QIODevice::Truncate | QIODevice::WriteOnly | QIODevice::Text)){
             QTextStream stream(currentFile);
             stream << textEditor->toPlainText();
-            saveState = false;
             changeState = false;
         } else {
             printf("Error : Cannot Open File");
         }
+        delete currentFile;
     }else{
         saveFileWithName();
     }
 }
 
-void Daruin::saveFileWithName()
+void Daruin::saveFileWithName(void)
 {
     *fileName = QFileDialog::getSaveFileName();
+
     if(*fileName != NULL){
         saveFile();
-        close_dialog();
-        switch(soState){
-            case 'n' : {
-                textEditor->clear();
-                fileName = new QString("");
-                break;
-            }
-            case 'e' : {
-                displayAskFileNameDialog();
-                break;
-            }
-            default  : {
-                break;
-            }
-        }
     }
-}
-
-void Daruin::close_dialog(void)
-{
-    switch(fileState){
-    case 'e' :
-    case 'n' : disconnect(yesButton , SIGNAL(clicked()) , this , SLOT(openFileWithSave()));	break;
-    case 'o' : disconnect(fileDialog , SIGNAL(fileSelected(QString)) , this , SLOT(openFileWithName(QString)));		break;
-    case 's' : disconnect(fileDialog , SIGNAL(fileSelected(QString)) , this , SLOT(saveFileWithName(QString)));	break;
-    }
-    dialog->hide();
-    soState = '\0';
 }

--- a/Daruin.h
+++ b/Daruin.h
@@ -36,7 +36,6 @@ public slots:
     void openFileWithName(QString name);
     void saveFile(void);
     void saveFileWithName(void);
-	void close_dialog(void);
 
 private:
     void displayAskSaveDialog(void);
@@ -46,7 +45,6 @@ private:
     QTextEdit* textEditor;
 	QMenuBar* menubar;
     QMenu* fileMenu;
-	QString* str;
     QString* fileName;
 
     QFileDialog* fileDialog;
@@ -60,9 +58,6 @@ private:
     QFile* currentFile;
 
     char fileState;
-
-    bool saveState;
-    char soState;
     bool changeState;
 };
 


### PR DESCRIPTION
必要ないと思われた部分の削減と，軽いバグの修正をした。
必要ないため削除した部分
・soState
（＊ここで，soStateの役割について確認しておく。まず，「ファイルを開く」を選ぶと，編集中の内容を保存するか聞かれるが，それに同意した場合について考える。このとき，編集中の内容をどのファイルに保存するかユーザーが入力するのをアプリは待機しており，その間，アプリは進行中の処理から離れる。ユーザーが入力を終えて，アプリが処理に戻った時，「ファイルを開く」という処理が進行中であるということをアプリに思い出させるのが，soStateの役割であった。しかし，QFileDialog::getSaveFileName()を使うことで，ユーザーの入力待機中に，アプリが進行中の処理から離れずに済むため，soStateが必要なくなったのである。）
・saveState
（＊soStateとほとんど同じ理由で必要なくなった。それほどに，たった一文でファイル名を取得できるQFileDialog::getSaveFileName()の存在は強大だったのだ。）
・close_dialog()
（＊各オブジェクトがコネクトされる関数が，ただひとつに定まるならば，コンストラクタでコネクトを一度実行すればよく，二回目以降のコネクトやディスコネクトを実行する必要がなくなる。すると，close_dialog()の中身がdialog->hide()だけになってしまったので，これは不必要とみなした。）

修正したバグ
・上書き保存をするとき，ファイル名を聞かれる又は最後に保存した別のファイルに保存される問題
solution: openFileWithName()内に，「_fileName = name;」 を挿入し解決
・「ファイルを開く」を選んだ後，現在編集中の内容を保存するか聞かれて，それに同意し，保存するファイル名を入力するためのダイアログが出る。そこで，「キャンセル」を押すと，そのダイアログが消えるのはいいのだが，開くファイルを選ぶダイアログが出てしまう。
solution: openFileWithName()内のopenFile()が，(_fileName != NULL)の条件を満たすなら実行されるようにして，解決

その他，細かい調整もあるが，大まかにはこういった修正をした。
